### PR TITLE
Fix generated comments

### DIFF
--- a/enumer.go
+++ b/enumer.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // Arguments to format are:
 //	[1]: type name
-const stringNameToValueMethod = `// %[1]sString retrieves an enum value from the enum constants string name.
-// Throws an error if the param is not part of the enum.
+const stringNameToValueMethod = `// %[1]sString returns a %[1]s for s.
+// It returns an error if s is not a %[1]s.
 func %[1]sString(s string) (%[1]s, error) {
 	if val, ok := _%[1]sNameToValueMap[s]; ok {
 		return val, nil
@@ -16,7 +16,7 @@ func %[1]sString(s string) (%[1]s, error) {
 
 // Arguments to format are:
 //	[1]: type name
-const stringValuesMethod = `// %[1]sValues returns all values of the enum
+const stringValuesMethod = `// %[1]sValues returns all values of the enum.
 func %[1]sValues() []%[1]s {
 	return _%[1]sValues
 }
@@ -24,7 +24,7 @@ func %[1]sValues() []%[1]s {
 
 // Arguments to format are:
 //	[1]: type name
-const stringBelongsMethodLoop = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
+const stringBelongsMethodLoop = `// IsA%[1]s reports whether the value is a member of the enum.
 func (i %[1]s) IsA%[1]s() bool {
 	for _, v := range _%[1]sValues {
 		if i == v {
@@ -37,9 +37,9 @@ func (i %[1]s) IsA%[1]s() bool {
 
 // Arguments to format are:
 //	[1]: type name
-const stringBelongsMethodSet = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
+const stringBelongsMethodSet = `// IsA%[1]s reports whether the value is a member of the enum.
 func (i %[1]s) IsA%[1]s() bool {
-	_, ok := _%[1]sMap[i] 
+	_, ok := _%[1]sMap[i]
 	return ok
 }
 `
@@ -88,13 +88,12 @@ func (g *Generator) buildBasicExtras(runs [][]Value, typeName string, runsThresh
 
 // Arguments to format are:
 //	[1]: type name
-const jsonMethods = `
-// MarshalJSON implements the json.Marshaler interface for %[1]s
+const jsonMethods = `// MarshalJSON implements the json.Marshaler interface.
 func (i %[1]s) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface for %[1]s
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (i *%[1]s) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -114,12 +113,12 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 // Arguments to format are:
 //	[1]: type name
 const textMethods = `
-// MarshalText implements the encoding.TextMarshaler interface for %[1]s
+// MarshalText implements the encoding.TextMarshaler interface.
 func (i %[1]s) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
 }
 
-// UnmarshalText implements the encoding.TextUnmarshaler interface for %[1]s
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (i *%[1]s) UnmarshalText(text []byte) error {
 	var err error
 	*i, err = %[1]sString(string(text))
@@ -133,13 +132,12 @@ func (g *Generator) buildTextMethods(runs [][]Value, typeName string, runsThresh
 
 // Arguments to format are:
 //	[1]: type name
-const yamlMethods = `
-// MarshalYAML implements a YAML Marshaler for %[1]s
+const yamlMethods = `// MarshalYAML implements the yaml.Marshaler interface.
 func (i %[1]s) MarshalYAML() (interface{}, error) {
 	return i.String(), nil
 }
 
-// UnmarshalYAML implements a YAML Unmarshaler for %[1]s
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (i *%[1]s) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {


### PR DESCRIPTION
- Add missing punctuation marks.
- Make comments more consistent with comments for similar functions
  in the standard library.